### PR TITLE
File dialog

### DIFF
--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -831,9 +831,14 @@ class FileDialog : Dialog, CustomGridCellAdapter {
         _fileList.minVisibleCols = 4;
         _fileList.headerCellClicked = &onHeaderCellClicked;
 
+        Widget buttonsPanel;
         _fileList.keyEvent = delegate(Widget source, KeyEvent event) {
             if (_shortcutHelper.onKeyEvent(event))
                 locateFileInList(_shortcutHelper.text);
+            if (event.keyCode == KeyCode.RETURN) {
+                buttonsPanel.setFocus();
+                return true;
+            }
             return false;
         };
 
@@ -844,9 +849,9 @@ class FileDialog : Dialog, CustomGridCellAdapter {
 
         addChild(content);
         if (_flags & FileDialogFlag.EnableCreateDirectory) {
-            addChild(createButtonsPanel([ACTION_CREATE_DIRECTORY, cast(immutable)_action, ACTION_CANCEL], 1, 1));
+            buttonsPanel = addChild(createButtonsPanel([ACTION_CREATE_DIRECTORY, cast(immutable)_action, ACTION_CANCEL], 1, 1));
         } else {
-            addChild(createButtonsPanel([cast(immutable)_action, ACTION_CANCEL], 0, 0));
+            buttonsPanel = addChild(createButtonsPanel([cast(immutable)_action, ACTION_CANCEL], 0, 0));
         }
 
         _fileList.customCellAdapter = this;

--- a/views/res/btn_background_transparent.xml
+++ b/views/res/btn_background_transparent.xml
@@ -4,7 +4,7 @@
     android:drawable="@null"
     android:state_enabled="false"/>
   <item
-    android:drawable="@null"
+    android:drawable="btn_hover"
     android:state_focused="true" />
   <item
     android:drawable="btn_pressed"

--- a/views/res/btn_background_transparent_dark.xml
+++ b/views/res/btn_background_transparent_dark.xml
@@ -4,7 +4,7 @@
     android:drawable="@null"
     android:state_enabled="false"/>
   <item
-    android:drawable="@null"
+    android:drawable="btn_hover_dark"
     android:state_focused="true" />
   <item
     android:drawable="btn_pressed_dark"


### PR DESCRIPTION
Input needs to to blocked on file dialog until releasing the enter key. Otherwise, if another dialog is shown right after it will be skipped. Also you can't currently see what is selected in the "favorites" pane using arrow keys. Or the pane buttons need their own theme.